### PR TITLE
Change Gambler to Duper - Add functionality

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -41,7 +41,7 @@ call :build
 echo Installing...
 copy "build\%ID%-%VERSION%.zip" "%MODS_PATH%\%ID%-%VERSION%.zip"
 powershell -Command "Expand-Archive -Path '%MODS_PATH%\%ID%-%VERSION%.zip' -DestinationPath '%MODS_PATH%' -Force"
-del "%MODS_PATH%\%ID%-%VERSION%.zip"
+del "%MODS_PATH%\%ID%-%VERSION%.zip" 2>nul
 exit /b
 
 :run

--- a/src/backs/backs1.lua
+++ b/src/backs/backs1.lua
@@ -9,7 +9,7 @@ local amplifydeck = {
 	discovered = true,
 	config = {
 		jokers = {
-			"j_amp_gambler"
+			"j_amp_duper"
 		},
 		consumables = {
 			"c_amp_radio", 
@@ -43,6 +43,7 @@ local amplifydeck = {
 									for k, v in ipairs(back.effect.config.jokers) do
 										local card = create_card('Joker', G.jokers, nil, nil, nil, nil, v, 'deck')
 										card:add_to_deck()
+										card:set_edition({negative = true}, true)
 										G.jokers:emplace(card)
 									end
 								return true

--- a/src/consumables/amplified1.lua
+++ b/src/consumables/amplified1.lua
@@ -17,17 +17,6 @@ local radio = {
 	end,
 
 	use = function (self, card, area, copier)
-		G.E_MANAGER:add_event(Event({
-			func = function()
-			local card = create_card('Joker', G.jokers, nil, 0, nil, nil, "j_amp_gambler", 'gambler')
-			card:add_to_deck()
-			G.jokers:emplace(card)
-			card:start_materialize()
-
-			return true
-			end
-		}))
-	
 		local chosen_joker = pseudorandom_element(G.jokers.cards, pseudoseed('amp'))
 
 		sendDebugMessage("Chosen joker: " .. inspect(chosen_joker.ability))

--- a/src/jokers/jokers1.lua
+++ b/src/jokers/jokers1.lua
@@ -1,6 +1,6 @@
-local gambler ={ 
-    key = "gambler",
-    name = "gambler",
+local duper ={ 
+    key = "duper",
+    name = "Duper",
     pos = {x = 0, y = 0},
     config = {extra = {h_size = 1}},
     rarity = 1, 
@@ -10,74 +10,14 @@ local gambler ={
     unlocked = true,
     discovered = true,
     calculate = function(self, card, context)
-     if context.setting_blind and not self.getting_sliced then
+      if context.using_consumeable and (context.consumeable.ability.set == "Amplify") then
         G.E_MANAGER:add_event(Event({
             func = function()
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_radio", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-                
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_speaker", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
+              local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, context.consumeable.config.center_key, nil)
+              card:add_to_deck()
+              G.consumeables:emplace(card)
 
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_headphones", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_antenna", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_sonar", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_satellite_dish", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_megaphone", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_microphone", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_oscillator", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_record_player", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_soundboard", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_tape_recorder", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_echo", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_equalizer", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_amplified", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                local card = create_card("Amplify", G.pack_cards, nil, nil, true, true, "c_amp_tuning_fork", nil)
-                card:add_to_deck()
-                G.consumeables:emplace(card)
-
-                return true
+              return true
             end
         }))
 
@@ -102,5 +42,5 @@ local gambler ={
 
 return {
     name = "Jokers",
-    list = {gambler}
+    list = {duper}
 }

--- a/src/localization/en-us.lua
+++ b/src/localization/en-us.lua
@@ -135,10 +135,11 @@ return {
             },
         },
         Joker = {
-            j_amp_gambler = {
-                name = "Gambler",
+            j_amp_duper = {
+                name = "Duper",
                 text = {
-                   "TODO",
+                   "Creates the last",
+                   "{C:amplify}Amplify{} card used during this run"
                 },
             },
         },


### PR DESCRIPTION
Change 'The Gambler' to 'Duper' modified functionality

Context: 
We wanted a joker for better debugging. As such this Joker was born. Whenever you use an amplify card it will immediately grant it back. This way we always have a full deck of amplify cards for testing. 

Changes:
- Changed the joker name and keys from "The Gambler" to "Duper".
- Modified functionality to create the last used amplify card instead of granting all 16 cards at start of round.
- Modified amplify deck so that you start with a negative version of the duper.